### PR TITLE
New player with auth (new API endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,7 @@ The build commands outputs to the dist folder where the front-end parts are outp
 | Variable Name | Description |
 | ------------- | ----------- |
 | EMBED_API_TOKEN | Required - Your TIDAL API token |
+| EMBED_API_PUBLIC_KEY | Required - API key for new Tidal API calls |
+| EMBED_API_TOKEN__NOSTR| Not required - for Nostr logged in full length playback support |
 | TRACK_JS_TOKEN | Not required - Specify along with TRACK_JS_APPLICATION to include TrackJS |
 | TRACK_JS_APPLICATION | Not required - Specify along with TRACK_JS_TOKEN to include TrackJS |

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gh-action:start": "LAMBDA_TASK_ROOT=true AWS_EXECUTION_ENV=true AWS_ENV=fakelamda node src/server/local/index.js"
   },
   "devDependencies": {
+    "@tidal-music/auth": "1.4.0",
     "@tidal-music/common": "0.2.0",
     "@tidal-music/event-producer": "2.4.0",
     "@tidal-music/player": "0.11.0",

--- a/scripts/esbuild-client.js
+++ b/scripts/esbuild-client.js
@@ -31,6 +31,7 @@ const context = await esbuild.context({
   define: {
     // @ts-ignore
     'process.env.EMBED_API_TOKEN': `'${process.env.EMBED_API_TOKEN}'`,
+    'process.env.EMBED_API_PUBLIC_KEY': `'${process.env.EMBED_API_PUBLIC_KEY}'`,
     'process.env.EMBED_API_TOKEN__NOSTR': `'${process.env.EMBED_API_TOKEN__NOSTR}'`,
   },
   plugins: [

--- a/src/client/js/playback/auth-provider.js
+++ b/src/client/js/playback/auth-provider.js
@@ -1,3 +1,5 @@
+import { credentialsProvider, init as authSDKInit } from '@tidal-music/auth';
+
 import DialogController from '../dialog-controller.js';
 
 /**
@@ -10,6 +12,28 @@ const credentialsUpdatedEvent = new CustomEvent('credentialsUpdated', {
 });
 
 class DefaultCredentialsProvider {
+  constructor() {
+    if (
+      !process.env.EMBED_API_TOKEN ||
+      !process.env.EMBED_API_PUBLIC_KEY ||
+      process.env.EMBED_API_PUBLIC_KEY === 'undefined'
+    ) {
+      throw new ReferenceError(
+        'You are running without setting an EMBED_API_TOKEN and an EMBED_API_PUBLIC_KEY variable',
+      );
+    }
+
+    authSDKInit({
+      clientId: process.env.EMBED_API_TOKEN,
+      clientSecret: process.env.EMBED_API_PUBLIC_KEY,
+      clientUniqueKey: 'tidal_embed_player',
+      credentialsStorageKey: 'tidal_embed_player',
+      scopes: [],
+      tidalAuthServiceBaseUri: 'https://auth.tidal.com/v1/',
+      tidalLoginServiceBaseUri: 'https://login.tidal.com/',
+    });
+  }
+
   /**
    * @type {import('@tidal-music/common/dist').Bus} fn
    */
@@ -20,17 +44,8 @@ class DefaultCredentialsProvider {
   /**
    * @type {import('@tidal-music/common/dist').GetCredentials} fn
    */
-  async getCredentials() {
-    if (process.env.EMBED_API_TOKEN) {
-      return {
-        clientId: process.env.EMBED_API_TOKEN,
-        requestedScopes: [],
-      };
-    }
-
-    throw new ReferenceError(
-      'You are running without setting an EMBED_API_TOKEN variable',
-    );
+  getCredentials(apiErrorSubStatus) {
+    return credentialsProvider.getCredentials(apiErrorSubStatus);
   }
 }
 


### PR DESCRIPTION
- Added @tidal-music/auth dependency to package.json.
- Updated README.md to include EMBED_API_PUBLIC_KEY variable.
- Enhanced DefaultCredentialsProvider to require EMBED_API_PUBLIC_KEY and initialize authentication SDK with both EMBED_API_TOKEN and EMBED_API_PUBLIC_KEY.

Will also need updated Player and  Player Web Components from the SDK: https://github.com/tidal-music/tidal-sdk-web/pull/465